### PR TITLE
Added Preload to delay transition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,3 @@
-
-
-
 <!DOCTYPE html>
 <html lang="en" class="no-js">
     <!-- Begin Head -->
@@ -42,12 +39,19 @@
     background-repeat: no-repeat;
     background-size: cover;
 }
+    /*Pre-Load*/
+    .preload * {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -ms-transition: none !important;
+  -o-transition: none !important;
+}
 </style>
     </head>
     <!-- End Head -->
 
     <!-- Body -->
-    <body>
+    <body class="preload">
 
         <!--========== HEADER ==========-->
         <header class="navbar-fixed-top s-header js__header-sticky js__header-overlay">
@@ -840,7 +844,11 @@ var x = setInterval(function() {
         <script type="text/javascript" src="js/components/wow.min.js"></script>
 
         <!--========== END JAVASCRIPTS ==========-->
-
+        <script>
+            $(window).load(function() {
+             $("body").removeClass("preload");
+            });
+        </script>
     </body>
     <!-- End Body -->
 </html>


### PR DESCRIPTION
Transitions Only After Page Load.

Bug Fixes ONLY. NO NEW FEATURE ACCEPTED!

**Description**
The transitions are loaded before full page loading.  This is prevented by disabling it till all page is fully loaded.
